### PR TITLE
core: several improvements on single-point exit

### DIFF
--- a/main.c
+++ b/main.c
@@ -88,7 +88,7 @@ int main(int _argc, char** _argv)
 				use_syslog = 1;
 				break;
 			default:
-				stop("Unknown option occurred");
+				stop_code(EX_USAGE, "Unknown option occurred");
 				break;
 		}
 	}
@@ -176,6 +176,6 @@ out:
 
 	pfcq_debug_done();
 
-	exit(EX_OK);
+	stop_code(EX_OK, NULL);
 }
 

--- a/pfcq.h
+++ b/pfcq.h
@@ -45,7 +45,8 @@
 
 #define warning(A)				__pfcq_warning(A, errno, __FILE__, __LINE__, 1)
 #define fail(A)					__pfcq_fail(A, errno)
-#define stop(A)					__pfcq_stop(EX_SOFTWARE, A)
+#define stop(A)					stop_code(EX_SOFTWARE, A)
+#define stop_code(A, B)			__pfcq_stop(A, B)
 #define panic(A)				__pfcq_panic(A, errno, __FILE__, __LINE__)
 
 #define pfcq_zero(A, B)			pfcq_memset_g(A, 0, B)


### PR DESCRIPTION
- correct exit code used on command line error
- main process exit now also uses __pfcq_stop()